### PR TITLE
Add ability to specify a rest provider.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,15 @@
     "url": "https://github.com/bitovi/testee-client/issues"
   },
   "homepage": "https://github.com/bitovi/testee-client",
-  "dependencies": {},
+  "dependencies": {
+    "feathers-rest": "^1.5.0",
+    "superagent": "^2.3.0"
+  },
   "devDependencies": {
     "chai": "^3.5.0",
     "core-js": "^2.4.1",
     "feathers": "^2.0.1",
+    "feathers-client": "^1.6.1",
     "feathers-socketio": "^1.4.1",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
@@ -65,7 +69,6 @@
     "qunitjs": "^1.23.1",
     "socket.io-client": "^1.4.8",
     "steal": "^1.0.0-rc.3",
-    "steal-tools": "^1.0.0-rc.1",
-    "wolfy87-eventemitter": "^5.1.0"
+    "steal-tools": "^1.0.0-rc.1"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -2,32 +2,102 @@
 
 [![Build Status](https://travis-ci.org/bitovi/testee-client.svg?branch=master)](https://travis-ci.org/bitovi/testee-client)
 
-Testee client side adapters for Mocha, QUnit and Jasmine that convert test results into Feathers service socket calls (`runs`, `suites` and `tests`).
+Testee client side adapters for Mocha, QUnit and Jasmine (1 and 2) that convert test results into Feathers service calls (`runs`, `suites`, `tests` and `coverages`).
 
 ## Initializing options
 
-In you test page you can set Testee options using `window.Testee`. To report to a different server for example set:
+In your test page you can set Testee options using `window.Testee`. 
+
+### BaseURL
+
+By default, the client will use the url the tests are running at (`window.location.protocol + '//' + window.location.host`). you can change this using the `baseURL` option:
 
 ```html
+<script type="text/javascript">
+window.Testee = {
+  baseURL: 'http://testee-server.com/'
+}
+</script>
+<script type="text/javascript" src="testee-client.js"></script>
+```
+
+### Provider
+
+By default, the client will use socket.io to make Feathers service calls. You can change this to use REST by specifying the `provider` option:
+
+```html
+<script type="text/javascript">
+window.Testee = {
+  provider: {
+    type: 'rest'
+  }
+}
+</script>
+<script type="text/javascript" src="testee-client.js"></script>
+```
+
+### Socket
+
+You can provide your own socket instance to make Feathers service calls using the `socket` option:
+
+```html
+<script type="text/javascript" src="http://testee-server.com/socket.io/socket.io.js"></script>
 <script type="text/javascript">
 window.Testee = {
   socket: io('http://testee-server.com/')
 }
 </script>
-<script type="text/javascript" src="http://testee-server.com/socket.io/socket.io.js"></script>
 <script type="text/javascript" src="testee-client.js"></script>
 ```
 
-When loading files asynchronously:
+## Asynchronous Loading
+
+When loading files asynchronously, you need to stop your testing framework from running until all test files are loaded. Then call `window.Testee.init()`. If you're using [steal](https://www.npmjs.com/package/steal), you can use the [steal-mocha](https://www.npmjs.com/package/steal-mocha), [steal-qunit](https://www.npmjs.com/package/steal-qunit) or [steal-jasmine](https://www.npmjs.com/package/steal-jasmine) libraries.
+
+### Mocha
 
 ```html
+<script type="text/javascript" src="//best/cdn/ever/mocha/mocha.js"></script>
+<script type="text/javascript" src="testee-client.js"></script>
 <script type="text/javascript">
-window.Testee = {
-  autoInit: false
-}
+define(['tests.js'], function() {
+  if(window.Testee) {
+    window.Testee.init();
+  }
+  mocha.run();
+});
+</script>
+```
 
-define(['testee-client', 'qunit'], function() {
-  window.Testee.init();
+### QUnit
+
+```html
+<script type="text/javascript" src="//best/cdn/ever/qunit.js"></script>
+<script type="text/javascript" src="testee-client.js"></script>
+<script type="text/javascript">
+QUnit.config.autorun = false;
+define(['tests.js'], function() {
+  if(window.Testee) {
+    window.Testee.init();
+  }
+  QUnit.load();
+});
+</script>
+```
+
+### Jasmine
+
+```html
+<script type="text/javascript" src="//best/cdn/ever/jasmine/jasmine.js"></script>
+<script type="text/javascript" src="//best/cdn/ever/jasmine/jasmine-html.js"></script>
+<script type="text/javascript" src="//best/cdn/ever/jasmine/boot.js"></script>
+<script type="text/javascript" src="testee-client.js"></script>
+<script type="text/javascript">
+define(['tests.js'], function() {
+  if(window.Testee) {
+    window.Testee.init();
+  }
+  window.onload();
 });
 </script>
 ```

--- a/src/runner.js
+++ b/src/runner.js
@@ -97,7 +97,7 @@ module.exports = function(options) {
       }
 
       this.call('runs', 'patch', data.id, data).then(function() {
-        if (typeof socket.disconnect === 'function') {
+        if (socket && typeof socket.disconnect === 'function') {
           socket.disconnect();
         }
       });

--- a/test/index.html
+++ b/test/index.html
@@ -29,7 +29,8 @@
 <script>
   window.Testee = {};
 </script>
-<script type="text/javascript" src="../node_modules/wolfy87-eventemitter/EventEmitter.js"></script>
+<script type="text/javascript" src="../node_modules/core-js/client/core.js"></script>
+<script type="text/javascript" src="../node_modules/feathers-client/dist/feathers.min.js"></script>
 <script type="text/javascript" src="commons.js"></script>
 <script type="text/javascript" src="qunit.test.js"></script>
 <script type="text/javascript" src="jasmine-1.test.js"></script>

--- a/test/jasmine-1.test.js
+++ b/test/jasmine-1.test.js
@@ -1,5 +1,4 @@
 (function(window, undefined) {
-	var options = window.getTesteeOptions('Jasmine1');
 
 	module('Jasmine 1.x adapter test');
 
@@ -101,15 +100,15 @@
 		}
 	}];
 
-	test('runs the Jasmine test and writes expected data to socket', function() {
+	window.getTesteeOptions('Jasmine1', expected);
+
+	test('runs the Jasmine test and writes expected data', function() {
 		// Insert the iframe with the test
 		var iframe = document.createElement('iframe');
-		var walker = window.walkExpected(expected, options.socket);
 
 		iframe.src = 'jasmine-1/jasmine.html';
 		document.getElementById('qunit-fixture').appendChild(iframe);
 
 		stop();
-		walker();
 	});
 })(this);

--- a/test/jasmine.test.js
+++ b/test/jasmine.test.js
@@ -1,5 +1,4 @@
 (function(window, undefined) {
-	var options = window.getTesteeOptions('Jasmine');
 
 	module('Jasmine 2.x adapter test');
 
@@ -107,15 +106,15 @@
 		}
 	}];
 
-	test('runs the Jasmine test and writes expected data to socket', function() {
+	window.getTesteeOptions('Jasmine', expected);
+
+	test('runs the Jasmine test and writes expected data', function() {
 		// Insert the iframe with the test
 		var iframe = document.createElement('iframe');
-		var walker = window.walkExpected(expected, options.socket);
 
 		iframe.src = 'jasmine/jasmine.html';
 		document.getElementById('qunit-fixture').appendChild(iframe);
 
 		stop();
-		walker();
 	});
 })(this);

--- a/test/mocha.test.js
+++ b/test/mocha.test.js
@@ -1,5 +1,4 @@
 (function(window, undefined) {
-  var options = window.getTesteeOptions('Mocha');
 
   module('Mocha adapter test');
 
@@ -165,15 +164,15 @@
     }
   }];
 
-  test('runs the Mocha test and writes expected data to socket', function() {
+  window.getTesteeOptions('Mocha', expected);
+
+  test('runs the Mocha test and writes expected data', function() {
     // Insert the iframe with the test
     var iframe = document.createElement('iframe');
-    var walker = window.walkExpected(expected, options.socket);
 
     iframe.src = 'mocha/mocha.html';
     document.getElementById('qunit-fixture').appendChild(iframe);
 
     stop();
-    walker();
   });
 })(this);

--- a/test/qunit.test.js
+++ b/test/qunit.test.js
@@ -1,5 +1,4 @@
 (function(window, undefined) {
-	var options = window.getTesteeOptions('QUnit');
 
 	module('QUnit adapter test');
 
@@ -138,15 +137,15 @@
 		}
 	}];
 
-	test('runs the QUnit test and writes expected data to socket', function() {
+	window.getTesteeOptions('QUnit', expected);
+
+	test('runs the QUnit test and writes expected data', function() {
 		// Insert the iframe with the test
 		var iframe = document.createElement('iframe');
-		var walker = window.walkExpected(expected, options.socket);
 
 		iframe.src = 'qunit/qunit.html';
 		document.getElementById('qunit-fixture').appendChild(iframe);
 
 		stop();
-		walker();
 	});
 })(this);


### PR DESCRIPTION
- Added check for `options.provider.type` 
  - `rest` will use `feathers-rest` with `superagant`
- Added `options.baseURL` which is used for rest and socket
- Refactored tests to check that the client is sending the right data to Feathers instead of checking the socket
