### PR TITLE
Adding state to passed and failed tests so Mocha reporters work properly

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -60,14 +60,16 @@ module.exports = function(options) {
 
     pass: function(data) {
       data = Object.assign({
-        status: 'passed'
+        status: 'passed',
+        state: 'passed'
       }, data);
       this.call('tests', 'patch', data.id, data);
     },
 
     fail: function(data) {
       data = Object.assign({
-        status: 'failed'
+        status: 'failed',
+        state: 'failed'
       }, data);
       this.call('tests', 'patch', data.id, data);
     },


### PR DESCRIPTION
Adding a state property to the test objects so mocha reporters can handle failed tests properly.

i.e The XUnit reporter adds a `<failure>` tag with a message [here](https://github.com/mochajs/mocha/blob/master/lib/reporters/xunit.js#L133) but only if `state === 'failed'`.