### PR TITLE
Fix infinite errors logged in Chrome for unhandled feathers error

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -12,12 +12,16 @@ module.exports = function(options) {
       var args = _.toArray(arguments).slice(2);
       var service = this[path];
 
-
-      // Chain this service call to make sure it only runs
-      // after all previous returned with an ACK
-      this.connect = this.connect.then(function() {
+      function cb() {
         return service[method].apply(service, args);
-      });
+      }
+      // Chain this service call to make sure it only runs
+      // after all previous returned with an ACK.
+      //
+      // If one fails, let it fail and error normally,
+      //  but continue with a resolved promise instead of a
+      //  rejected one.
+      this.connect = this.connect.then(cb, cb);
 
       return this.connect;
     },


### PR DESCRIPTION
Letting the promise for the Feathers service be unhandled in the reject case led to an infinite loop of:

- mocha traps unhandled promise rejection
- mocha logs error
- testee captures log and sends to runner
- runner creates new promise from .then() of rejected one
- new promise rejects, unhandled
- repeat

For some reason only Chrome seemed to be affected by this, but it was causing 100% CPU usage for some unhandled errors.  This is a simple fix to address the problem, by ensuring that the pipeline queue for api calls always resolves even when the api call itself rejects.