### PR TITLE
Client-only workaround for handling mocha hook errors

### DIFF
--- a/src/adapters/mocha.js
+++ b/src/adapters/mocha.js
@@ -42,6 +42,10 @@ function TesteeReporter(runner) {
 
   pipe('fail', function(data, err) {
     var diff;
+    // Note: this is a workaround until https://github.com/bitovi/testee-client/pull/43
+    //  can be merged.  The associated server PR https://github.com/bitovi/testee/pull/163
+    //  currently is failing to pass the tests, so #43 cannot be merged. Once that is working
+    //  working, this change should be reverted. --BM 2018-06-06
     var title = data.title;
     if(data && data.type === "hook") {
       if(data.ctx.currentTest) {

--- a/src/adapters/mocha.js
+++ b/src/adapters/mocha.js
@@ -41,11 +41,29 @@ function TesteeReporter(runner) {
   });
 
   pipe('fail', function(data, err) {
-    var diff = self.diff(data);
+    var diff;
+    var title = data.title;
+    if(data && data.type === "hook") {
+      if(data.ctx.currentTest) {
+        data = data.ctx.currentTest;
+      } else if(data.title === '"before all" hook') {
+        // tests in this suite will never run if before() fails,
+        //  so create the first test in order to fail it.
+        data = data.parent.tests[0];
+        diff = self.diff(data);
+        self.api['test'](diff);
+      } else {
+        // after all hook.  apply to last test, which has already ran
+        data = data.parent.tests[data.parent.tests.length - 1];
+      }
+    }
+
+    diff = self.diff(data);
     diff.err = {
       message: err.message,
       stack: err.stack || ''
     };
+    diff.title = title;
     return diff;
   });
 

--- a/test/mocha/mocha-errors.html
+++ b/test/mocha/mocha-errors.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Mocha</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <link rel="stylesheet" href="../../node_modules/mocha/mocha.css" />
+</head>
+<body>
+  <div id="mocha"></div>
+
+  <script src="../../node_modules/chai/chai.js" type="text/javascript"></script>
+  <script src="../../node_modules/mocha/mocha.js" type="text/javascript"></script>
+  <script type="text/javascript">
+    mocha.setup('bdd');
+
+    onload = function () {
+      mocha.run();
+    };
+
+    window.expect = chai.expect;
+
+    window.__coverage__ = { test: 'Mocha coverage' };
+    window.Testee = window.top.TesteeMock;
+  </script>
+
+  <script type="text/javascript" src="../../dist/testee.js"></script>
+  <script type="text/javascript" src="test-errors.js"></script>
+</body>
+</html>

--- a/test/mocha/test-errors.js
+++ b/test/mocha/test-errors.js
@@ -1,0 +1,36 @@
+describe('mocha', function() {
+  describe('Errors in setup/teardown', function() {
+    describe('before', function() {
+      before(function() {
+        throw new Error('Test error');
+      })
+      it('passes', function() {
+        expect(true).to.equal(true);
+      })
+    })
+    describe('beforeEach', function() {
+      beforeEach(function() {
+        throw new Error('Test error');
+      })
+      it('passes', function() {
+        expect(true).to.equal(true);
+      })
+    })
+    describe('afterEach', function() {
+      afterEach(function() {
+        throw new Error('Test error');
+      })
+      it('passes', function() {
+        expect(true).to.equal(true);
+      })
+    })
+    describe('after', function() {
+      after(function() {
+        throw new Error('Test error');
+      })
+      it('passes', function() {
+        expect(true).to.equal(true);
+      })
+    })
+  })
+});

--- a/test/mocha/test.js
+++ b/test/mocha/test.js
@@ -24,5 +24,4 @@ describe('Test module', function() {
       });
     });
   });
-
 });

--- a/test/test.js
+++ b/test/test.js
@@ -567,6 +567,224 @@ unit.test(
   testTester('mocha/mocha.html', mochaSnapshot)
 );
 
+// var mochaErrorsSnapshot = [{
+//   "name": "api/runs::create",
+//   "data": {
+//     "status": "running",
+//     "environment": navigator.userAgent,
+//     "runner": "Mocha",
+//     "file": /mocha\/mocha-errors\.html/
+//   }
+// }, {
+//   "name": "api/suites::create",
+//   "data": {
+//     "status": "running",
+//     "title": "",
+//     "pending": false,
+//     "root": true,
+//     "file": /mocha\/mocha-errors\.html/
+//   }
+// }, {
+//   "name": "api/suites::create",
+//   "data": {
+//     "status": "running",
+//     "title": "mocha",
+//     "pending": false,
+//     "root": false,
+//     "file": /mocha\/mocha-errors\.html/
+//   }
+// }, {
+//   "name": "api/suites::create",
+//   "data": {
+//     "status": "running",
+//     "title": "Errors in setup/teardown",
+//     "pending": false,
+//     "root": false,
+//     "file": /mocha\/mocha-errors\.html/
+//   }
+// }, {
+//   "name": "api/suites::create",
+//   "data": {
+//     "status": "running",
+//     "title": "before",
+//     "pending": false,
+//     "root": false,
+//     "file": /mocha\/mocha-errors\.html/
+//   }
+// }, {
+//   "name": "api/tests::create",
+//   "data": {
+//     "title": "passes",
+//     "sync": true,
+//     "timedOut": false,
+//     //"pending": true,
+//     "type": "test",
+//     //"status": "pending",
+//     "file": /mocha\/mocha-errors\.html/
+//   }
+// }, {
+//   "name": "api/tests::patch",
+//   "data": {
+//     "status": "failed",
+//     "state": "failed",
+//     "title": "\"before all\" hook",
+//     "err": {
+//       "message": "Test error"
+//     }
+//   }
+// }, {
+//   "name": "api/suites::patch",
+//   "data": {
+//     "status": "finished"
+//   }
+// }, {
+//   "name": "api/suites::create",
+//   "data": {
+//     "status": "running",
+//     "title": "beforeEach",
+//     "pending": false,
+//     "root": false,
+//     "file": /mocha\/mocha-errors\.html/
+//   }
+// }, {
+//   "name": "api/tests::create",
+//   "data": {
+//     "title": "passes",
+//     "sync": true,
+//     "timedOut": false,
+//     "type": "test",
+//     "file": /mocha\/mocha-errors\.html/
+//   }
+// }, {
+//   "name": "api/tests::patch",
+//   "data": {
+//     "status": "failed",
+//     "state": "failed",
+//     "title": "\"before each\" hook for \"passes\"",
+//     "err": {
+//       "message": "Test error"
+//     }
+//   }
+// }, {
+//   "name": "api/suites::patch",
+//   "data": {
+//     "status": "finished"
+//   }
+// }, {
+//   "name": "api/suites::create",
+//   "data": {
+//     "status": "running",
+//     "title": "afterEach",
+//     "pending": false,
+//     "root": false,
+//     "file": /mocha\/mocha-errors\.html/
+//   }
+// }, {
+//   "name": "api/tests::create",
+//   "data": {
+//     "title": "passes",
+//     "sync": true,
+//     "timedOut": false,
+//     "type": "test",
+//     "file": /mocha\/mocha-errors\.html/
+//   }
+// }, {
+//   "name": "api/tests::patch",
+//   "data": {
+//     "status": "passed",
+//     "state": "passed"
+//   }
+// }, {
+//   "name": "api/tests::patch",
+//   "data": {
+//     "status": "failed",
+//     "state": "failed",
+//     "title": "\"after each\" hook for \"passes\"",
+//     "err": {
+//       "message": "Test error"
+//     }
+//   }
+// }, {
+//   "name": "api/suites::patch",
+//   "data": {
+//     "status": "finished"
+//   }
+// }, {
+//   "name": "api/suites::create",
+//   "data": {
+//     "status": "running",
+//     "title": "after",
+//     "pending": false,
+//     "root": false,
+//     "file": /mocha\/mocha-errors\.html/
+//   }
+// }, {
+//   "name": "api/tests::create",
+//   "data": {
+//     "title": "passes",
+//     "sync": true,
+//     "timedOut": false,
+//     "type": "test",
+//     "file": /mocha\/mocha-errors\.html/
+//   }
+// }, {
+//   "name": "api/tests::patch",
+//   "data": {
+//     "status": "passed",
+//     "state": "passed"
+//   }
+// }, {
+//   "name": "api/tests::patch",
+//   "data": {
+//     "status": "failed",
+//     "state": "failed",
+//     "title": "\"after all\" hook",
+//     "err": {
+//       "message": "Test error"
+//     }
+//   }
+// }, {
+//   "name": "api/suites::patch",
+//   "data": {
+//     "status": "finished"
+//   }
+// }, {
+//   "name": "api/suites::patch",
+//   "data": {
+//     "status": "finished"
+//   }
+// }, {
+//   "name": "api/suites::patch",
+//   "data": {
+//     "status": "finished"
+//   }
+// }, {
+//   "name": "api/suites::patch",
+//   "data": {
+//     "status": "finished"
+//   }
+// }, {
+//   "name": "api/coverages::create",
+//   "data": {
+//     coverage: {
+//       "test": "Mocha coverage"
+//     }
+//   }
+// }, {
+//   "name": "api/runs::patch",
+//   "data": {
+//     "status": "finished",
+//     "total": 6,
+//     "failed": 4,
+//     "pending": 0,
+//     "passed": 2
+//   }
+// }];
+// unit.test(
+//   'runs the Mocha test and errors as appropriate',
+//   testTester('mocha/mocha-errors.html', mochaErrorsSnapshot)
+// );
+
 var jasmineSnapshot = [{
   "name": "api/runs::create",
   "data": {

--- a/test/test.js
+++ b/test/test.js
@@ -567,223 +567,223 @@ unit.test(
   testTester('mocha/mocha.html', mochaSnapshot)
 );
 
-// var mochaErrorsSnapshot = [{
-//   "name": "api/runs::create",
-//   "data": {
-//     "status": "running",
-//     "environment": navigator.userAgent,
-//     "runner": "Mocha",
-//     "file": /mocha\/mocha-errors\.html/
-//   }
-// }, {
-//   "name": "api/suites::create",
-//   "data": {
-//     "status": "running",
-//     "title": "",
-//     "pending": false,
-//     "root": true,
-//     "file": /mocha\/mocha-errors\.html/
-//   }
-// }, {
-//   "name": "api/suites::create",
-//   "data": {
-//     "status": "running",
-//     "title": "mocha",
-//     "pending": false,
-//     "root": false,
-//     "file": /mocha\/mocha-errors\.html/
-//   }
-// }, {
-//   "name": "api/suites::create",
-//   "data": {
-//     "status": "running",
-//     "title": "Errors in setup/teardown",
-//     "pending": false,
-//     "root": false,
-//     "file": /mocha\/mocha-errors\.html/
-//   }
-// }, {
-//   "name": "api/suites::create",
-//   "data": {
-//     "status": "running",
-//     "title": "before",
-//     "pending": false,
-//     "root": false,
-//     "file": /mocha\/mocha-errors\.html/
-//   }
-// }, {
-//   "name": "api/tests::create",
-//   "data": {
-//     "title": "passes",
-//     "sync": true,
-//     "timedOut": false,
-//     //"pending": true,
-//     "type": "test",
-//     //"status": "pending",
-//     "file": /mocha\/mocha-errors\.html/
-//   }
-// }, {
-//   "name": "api/tests::patch",
-//   "data": {
-//     "status": "failed",
-//     "state": "failed",
-//     "title": "\"before all\" hook",
-//     "err": {
-//       "message": "Test error"
-//     }
-//   }
-// }, {
-//   "name": "api/suites::patch",
-//   "data": {
-//     "status": "finished"
-//   }
-// }, {
-//   "name": "api/suites::create",
-//   "data": {
-//     "status": "running",
-//     "title": "beforeEach",
-//     "pending": false,
-//     "root": false,
-//     "file": /mocha\/mocha-errors\.html/
-//   }
-// }, {
-//   "name": "api/tests::create",
-//   "data": {
-//     "title": "passes",
-//     "sync": true,
-//     "timedOut": false,
-//     "type": "test",
-//     "file": /mocha\/mocha-errors\.html/
-//   }
-// }, {
-//   "name": "api/tests::patch",
-//   "data": {
-//     "status": "failed",
-//     "state": "failed",
-//     "title": "\"before each\" hook for \"passes\"",
-//     "err": {
-//       "message": "Test error"
-//     }
-//   }
-// }, {
-//   "name": "api/suites::patch",
-//   "data": {
-//     "status": "finished"
-//   }
-// }, {
-//   "name": "api/suites::create",
-//   "data": {
-//     "status": "running",
-//     "title": "afterEach",
-//     "pending": false,
-//     "root": false,
-//     "file": /mocha\/mocha-errors\.html/
-//   }
-// }, {
-//   "name": "api/tests::create",
-//   "data": {
-//     "title": "passes",
-//     "sync": true,
-//     "timedOut": false,
-//     "type": "test",
-//     "file": /mocha\/mocha-errors\.html/
-//   }
-// }, {
-//   "name": "api/tests::patch",
-//   "data": {
-//     "status": "passed",
-//     "state": "passed"
-//   }
-// }, {
-//   "name": "api/tests::patch",
-//   "data": {
-//     "status": "failed",
-//     "state": "failed",
-//     "title": "\"after each\" hook for \"passes\"",
-//     "err": {
-//       "message": "Test error"
-//     }
-//   }
-// }, {
-//   "name": "api/suites::patch",
-//   "data": {
-//     "status": "finished"
-//   }
-// }, {
-//   "name": "api/suites::create",
-//   "data": {
-//     "status": "running",
-//     "title": "after",
-//     "pending": false,
-//     "root": false,
-//     "file": /mocha\/mocha-errors\.html/
-//   }
-// }, {
-//   "name": "api/tests::create",
-//   "data": {
-//     "title": "passes",
-//     "sync": true,
-//     "timedOut": false,
-//     "type": "test",
-//     "file": /mocha\/mocha-errors\.html/
-//   }
-// }, {
-//   "name": "api/tests::patch",
-//   "data": {
-//     "status": "passed",
-//     "state": "passed"
-//   }
-// }, {
-//   "name": "api/tests::patch",
-//   "data": {
-//     "status": "failed",
-//     "state": "failed",
-//     "title": "\"after all\" hook",
-//     "err": {
-//       "message": "Test error"
-//     }
-//   }
-// }, {
-//   "name": "api/suites::patch",
-//   "data": {
-//     "status": "finished"
-//   }
-// }, {
-//   "name": "api/suites::patch",
-//   "data": {
-//     "status": "finished"
-//   }
-// }, {
-//   "name": "api/suites::patch",
-//   "data": {
-//     "status": "finished"
-//   }
-// }, {
-//   "name": "api/suites::patch",
-//   "data": {
-//     "status": "finished"
-//   }
-// }, {
-//   "name": "api/coverages::create",
-//   "data": {
-//     coverage: {
-//       "test": "Mocha coverage"
-//     }
-//   }
-// }, {
-//   "name": "api/runs::patch",
-//   "data": {
-//     "status": "finished",
-//     "total": 6,
-//     "failed": 4,
-//     "pending": 0,
-//     "passed": 2
-//   }
-// }];
-// unit.test(
-//   'runs the Mocha test and errors as appropriate',
-//   testTester('mocha/mocha-errors.html', mochaErrorsSnapshot)
-// );
+var mochaErrorsSnapshot = [{
+  "name": "api/runs::create",
+  "data": {
+    "status": "running",
+    "environment": navigator.userAgent,
+    "runner": "Mocha",
+    "file": /mocha\/mocha-errors\.html/
+  }
+}, {
+  "name": "api/suites::create",
+  "data": {
+    "status": "running",
+    "title": "",
+    "pending": false,
+    "root": true,
+    "file": /mocha\/mocha-errors\.html/
+  }
+}, {
+  "name": "api/suites::create",
+  "data": {
+    "status": "running",
+    "title": "mocha",
+    "pending": false,
+    "root": false,
+    "file": /mocha\/mocha-errors\.html/
+  }
+}, {
+  "name": "api/suites::create",
+  "data": {
+    "status": "running",
+    "title": "Errors in setup/teardown",
+    "pending": false,
+    "root": false,
+    "file": /mocha\/mocha-errors\.html/
+  }
+}, {
+  "name": "api/suites::create",
+  "data": {
+    "status": "running",
+    "title": "before",
+    "pending": false,
+    "root": false,
+    "file": /mocha\/mocha-errors\.html/
+  }
+}, {
+  "name": "api/tests::create",
+  "data": {
+    "title": "passes",
+    "sync": true,
+    "timedOut": false,
+    //"pending": true,
+    "type": "test",
+    //"status": "pending",
+    "file": /mocha\/mocha-errors\.html/
+  }
+}, {
+  "name": "api/tests::patch",
+  "data": {
+    "status": "failed",
+    "state": "failed",
+    "title": "\"before all\" hook",
+    "err": {
+      "message": "Test error"
+    }
+  }
+}, {
+  "name": "api/suites::patch",
+  "data": {
+    "status": "finished"
+  }
+}, {
+  "name": "api/suites::create",
+  "data": {
+    "status": "running",
+    "title": "beforeEach",
+    "pending": false,
+    "root": false,
+    "file": /mocha\/mocha-errors\.html/
+  }
+}, {
+  "name": "api/tests::create",
+  "data": {
+    "title": "passes",
+    "sync": true,
+    "timedOut": false,
+    "type": "test",
+    "file": /mocha\/mocha-errors\.html/
+  }
+}, {
+  "name": "api/tests::patch",
+  "data": {
+    "status": "failed",
+    "state": "failed",
+    "title": "\"before each\" hook for \"passes\"",
+    "err": {
+      "message": "Test error"
+    }
+  }
+}, {
+  "name": "api/suites::patch",
+  "data": {
+    "status": "finished"
+  }
+}, {
+  "name": "api/suites::create",
+  "data": {
+    "status": "running",
+    "title": "afterEach",
+    "pending": false,
+    "root": false,
+    "file": /mocha\/mocha-errors\.html/
+  }
+}, {
+  "name": "api/tests::create",
+  "data": {
+    "title": "passes",
+    "sync": true,
+    "timedOut": false,
+    "type": "test",
+    "file": /mocha\/mocha-errors\.html/
+  }
+}, {
+  "name": "api/tests::patch",
+  "data": {
+    "status": "passed",
+    "state": "passed"
+  }
+}, {
+  "name": "api/tests::patch",
+  "data": {
+    "status": "failed",
+    "state": "failed",
+    "title": "\"after each\" hook for \"passes\"",
+    "err": {
+      "message": "Test error"
+    }
+  }
+}, {
+  "name": "api/suites::patch",
+  "data": {
+    "status": "finished"
+  }
+}, {
+  "name": "api/suites::create",
+  "data": {
+    "status": "running",
+    "title": "after",
+    "pending": false,
+    "root": false,
+    "file": /mocha\/mocha-errors\.html/
+  }
+}, {
+  "name": "api/tests::create",
+  "data": {
+    "title": "passes",
+    "sync": true,
+    "timedOut": false,
+    "type": "test",
+    "file": /mocha\/mocha-errors\.html/
+  }
+}, {
+  "name": "api/tests::patch",
+  "data": {
+    "status": "passed",
+    "state": "passed"
+  }
+}, {
+  "name": "api/tests::patch",
+  "data": {
+    "status": "failed",
+    "state": "failed",
+    "title": "\"after all\" hook",
+    "err": {
+      "message": "Test error"
+    }
+  }
+}, {
+  "name": "api/suites::patch",
+  "data": {
+    "status": "finished"
+  }
+}, {
+  "name": "api/suites::patch",
+  "data": {
+    "status": "finished"
+  }
+}, {
+  "name": "api/suites::patch",
+  "data": {
+    "status": "finished"
+  }
+}, {
+  "name": "api/suites::patch",
+  "data": {
+    "status": "finished"
+  }
+}, {
+  "name": "api/coverages::create",
+  "data": {
+    coverage: {
+      "test": "Mocha coverage"
+    }
+  }
+}, {
+  "name": "api/runs::patch",
+  "data": {
+    "status": "finished",
+    "total": 6,
+    "failed": 4,
+    "pending": 0,
+    "passed": 2
+  }
+}];
+unit.test(
+  'runs the Mocha test and errors as appropriate',
+  testTester('mocha/mocha-errors.html', mochaErrorsSnapshot)
+);
 
 var jasmineSnapshot = [{
   "name": "api/runs::create",


### PR DESCRIPTION
Currently there is a broken proposed fix for mocha errors happening on before/after hooks:

* #43  [client]
* bitovi/testee#163 [server]

The server portion is currently unworkable (tests fail), so the client part cannot be merged.  This is a workaround that shunts failures on mocha hooks into the contextually closest test in the current suite.