### PR TITLE
fix before/after all hooks not finding tests that aren't direct children of parent

### DIFF
--- a/src/adapters/mocha.js
+++ b/src/adapters/mocha.js
@@ -53,12 +53,18 @@ function TesteeReporter(runner) {
       } else if(data.title === '"before all" hook') {
         // tests in this suite will never run if before() fails,
         //  so create the first test in order to fail it.
-        data = data.parent.tests[0];
+        var test;
+        data.parent.eachTest(function(t) {
+          test = test || t;
+        })
+        data = test;
         diff = self.diff(data);
         self.api['test'](diff);
       } else {
         // after all hook.  apply to last test, which has already ran
-        data = data.parent.tests[data.parent.tests.length - 1];
+        data.parent.eachTest(function(t) {
+          data = t;
+        })
       }
     }
 

--- a/src/adapters/mocha.js
+++ b/src/adapters/mocha.js
@@ -57,7 +57,7 @@ function TesteeReporter(runner) {
         data.parent.eachTest(function(t) {
           test = test || t;
         })
-        data = test;
+        data = test || data;
         diff = self.diff(data);
         self.api['test'](diff);
       } else {

--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,7 @@ function compare (assert, reference, actual, name) {
     } else if(key === 'duration') {
       assert.ok(inRange(expected, current, 20), name + ' ' + key + ' === ' + expected + '(+/- 20)');
     } else {
-      assert.equal(expected, current, name + ' ' + key + ' === ' + expected);
+      assert.equal(current, expected, name + ' ' + key + ' === ' + expected);
     }
   }
 }


### PR DESCRIPTION
As a refinement of #45 -- I just realized that failures on the before all / after all hooks might not find a test to glom onto if there wasn't a test that was a direct sibling.  This fix uses eachTest() to always find a suitable test to fail when one of these hooks fails, as long as one exists in the suite.