### PR TITLE
Fix test/build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "meta": {
       "core-js/client/core": {
-        "format": "amd"
+        "format": "global"
       },
       "socket.io-client/dist/socket.io": {
         "format": "amd"
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "core-js": "^2.4.1",
+    "core-js": "^2.5.7",
     "feathers": "^2.0.1",
     "feathers-client": "^1.6.1",
     "feathers-socketio": "^1.4.1",
@@ -60,7 +60,7 @@
     "lodash": "^4.15.0",
     "md5": "^2.2.1",
     "mocha": "^3.0.2",
-    "qunitjs": "^2.1.1",
+    "qunit": "^2.4.1",
     "socket.io-client": "^1.7.2",
     "steal": "^1.0.0-rc.3",
     "steal-tools": "^1.0.0-rc.1"

--- a/test/index.html
+++ b/test/index.html
@@ -3,7 +3,7 @@
 <html>
 <head>
   <title>Unit test framework adapter tests</title>
-  <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css" type="text/css" media="screen"/>
+  <link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css" type="text/css" media="screen"/>
 </head>
 <body>
 <style type="text/css">
@@ -25,7 +25,7 @@
 <ol id="qunit-tests"></ol>
 <div id="qunit-fixture">test markup, will be hidden</div>
 
-<script type="text/javascript" src="../node_modules/qunitjs/qunit/qunit.js"></script>
+<script type="text/javascript" src="../node_modules/qunit/qunit/qunit.js"></script>
 <script>
   window.Testee = {};
 </script>

--- a/test/qunit/test.js
+++ b/test/qunit/test.js
@@ -1,4 +1,4 @@
-module('Test module');
+QUnit.module('Test module');
 
 test('A failing test', function() {
   equal('A', 'B', 'This test should fail');
@@ -10,7 +10,7 @@ test('It does something', function() {
   console.log('This is a test of console.log collection');
 });
 
-module('Other module');
+QUnit.module('Other module');
 
 test('It does something async', function() {
   stop();

--- a/test/qunit2/qunit2.html
+++ b/test/qunit2/qunit2.html
@@ -12,7 +12,7 @@
   <ol id="qunit-tests"></ol>
   <div id="qunit-fixture">test markup, will be hidden</div>
 
-  <script type="text/javascript" src="../../node_modules/qunitjs/qunit/qunit.js"></script>
+  <script type="text/javascript" src="../../node_modules/qunit/qunit/qunit.js"></script>
   <script type="text/javascript">
     window.Testee = window.top.TesteeMock;
     window.__coverage__ = { test: 'Qunit coverage' };


### PR DESCRIPTION
Fixes tests:
- Use `qunit` package for `QUnit V2` instead of `qunitjs` and fix paths in tests
- Fix qunit1 errors in tests
- Fix `core-js` `meta` in `packages.json` for steal to use global instead of `amd` module.

Fixes #48 